### PR TITLE
Fix disconnected status

### DIFF
--- a/json.go
+++ b/json.go
@@ -2,9 +2,11 @@ package main
 
 import (
 	"encoding/json"
+	"strings"
 )
 
 type Status struct {
+	TailscaleUp bool
 	Self  Machine
 	Peers map[string]Machine
 }
@@ -21,6 +23,8 @@ func (s *Status) UnmarshalJSON(data []byte) error {
 		return err
 	}
 
+	isRunning := strings.Contains(rawStatus.BackendState, "Running")
+
 	peers := map[string]Machine{}
 
 	for name, rawPeer := range rawStatus.Peers {
@@ -30,6 +34,7 @@ func (s *Status) UnmarshalJSON(data []byte) error {
 	self := rawStatus.Self.ToMachine(rawStatus.MagicDNSSuffix)
 
 	*s = Status{
+		TailscaleUp: isRunning,
 		Self:  self,
 		Peers: peers,
 	}
@@ -38,6 +43,7 @@ func (s *Status) UnmarshalJSON(data []byte) error {
 }
 
 type rawStatus struct {
+	BackendState   string
 	Self           RawMachine            `json:"Self"`
 	Peers          map[string]RawMachine `json:"Peer"`
 	MagicDNSSuffix string                `json:"MagicDNSSuffix"`

--- a/main.go
+++ b/main.go
@@ -136,7 +136,6 @@ func onReady() {
 				systray.SetIcon(iconOff)
 				enabled = false
 			}
-			time.Sleep(10 * time.Second)
 		}
 
 		for {
@@ -156,12 +155,14 @@ func onReady() {
 			myIP = status.Self.TailscaleIPs[0]
 			mu.Unlock()
 
-			if !enabled {
+			if status.TailscaleUp && !enabled {
 				systray.SetTooltip("Tailscale: Connected")
 				mConnect.Disable()
 				mDisconnect.Enable()
 				systray.SetIcon(iconOn)
 				enabled = true
+			} else if !status.TailscaleUp && enabled{
+				setDisconnected()
 			}
 
 			for _, v := range items {


### PR DESCRIPTION
After the merge of #12 , the disconnected status only appeared on errors, not while the tailscale connection was stopped.