### PR TITLE
Update systray version to 1.2.1 to fix broken dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ $ tailscale-systray
 
 ### Install requirements
 
-Building app require gcc, libgtk-3-dev, libappindicator-3-dev
+Building app requires gcc, libgtk-3-dev, libayatana-appindicator3-dev
 
 ```
-sudo apt-get install gcc libgtk-3-dev libappindicator3-dev
+sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev
 ```
 
 ### Install app

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.17
 require (
 	github.com/atotto/clipboard v0.1.4
 	github.com/gen2brain/beeep v0.0.0-20210529141713-5586760f0cc1
-	github.com/getlantern/systray v1.1.0
+	github.com/getlantern/systray v1.2.1
 	tailscale.com v1.18.2
 )
 

--- a/go.sum
+++ b/go.sum
@@ -156,8 +156,8 @@ github.com/getlantern/hidden v0.0.0-20201229170000-e66e7f878730/go.mod h1:6mmzY2
 github.com/getlantern/ops v0.0.0-20190325191751-d70cb0d6f85f/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
 github.com/getlantern/ops v0.0.0-20200403153110-8476b16edcd6 h1:QthAQCekS1YOeYWSvoHI6ZatlG4B+GBDLxV/2ZkBsTA=
 github.com/getlantern/ops v0.0.0-20200403153110-8476b16edcd6/go.mod h1:D5ao98qkA6pxftxoqzibIBBrLSUli+kYnJqrgBf9cIA=
-github.com/getlantern/systray v1.1.0 h1:U0wCEqseLi2ok1fE6b88gJklzriavPJixZysZPkZd/Y=
-github.com/getlantern/systray v1.1.0/go.mod h1:AecygODWIsBquJCJFop8MEQcJbWFfw/1yWbVabNgpCM=
+github.com/getlantern/systray v1.2.1 h1:udsC2k98v2hN359VTFShuQW6GGprRprw6kD6539JikI=
+github.com/getlantern/systray v1.2.1/go.mod h1:AecygODWIsBquJCJFop8MEQcJbWFfw/1yWbVabNgpCM=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.6.3/go.mod h1:75u5sXoLsGZoRN5Sgbi1eraJ4GU3++wFwWzhwvtwp4M=


### PR DESCRIPTION


libappindicator-3-dev is no longer available on latest ubuntu/debian systems, and is instead replaced by libayatana-appindicator3-dev

This pull request updates the dependency version to use the correct library