### PR TITLE
Updated readme to include installing go and the full path to running …

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ $ tailscale-systray
 
 ### Install requirements
 
-Building app requires gcc, libgtk-3-dev, libayatana-appindicator3-dev
+Building app requires go, gcc, libgtk-3-dev, libayatana-appindicator3-dev
 
 ```
-sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev
+sudo apt-get install golang-go gcc libgtk-3-dev libayatana-appindicator3-dev
 ```
 
 ### Install app
@@ -30,7 +30,7 @@ sudo apt-get install gcc libgtk-3-dev libayatana-appindicator3-dev
 go install -v github.com/mattn/tailscale-systray@latest
 ```
 
-At this point you can start it with `tailscale-systray`.
+At this point you can start it with `$HOME/go/bin/tailscale-systray`.
 
 ### Run at startup
 


### PR DESCRIPTION
…the compiled program.

The go compiler needs to be installed before running the go command.

Since the compiled program is in ~/go/bin/, the command to run it after compiling was updated to include the path.